### PR TITLE
CORS allowed headers workaround in auth/auth-info

### DIFF
--- a/confidential_backend/__init__.py
+++ b/confidential_backend/__init__.py
@@ -1,0 +1,1 @@
+PROXY_HEADERS = ('Authorization', 'Cache-Control', 'Content-Type')

--- a/confidential_backend/api/fhir.py
+++ b/confidential_backend/api/fhir.py
@@ -3,6 +3,7 @@ import requests
 from flask import Blueprint, current_app, g, request
 from flask_cors import cross_origin
 
+from confidential_backend import PROXY_HEADERS
 from confidential_backend.audit import audit_entry
 from confidential_backend.jsonify_abort import jsonify_abort
 from confidential_backend.wrapped_session import get_session_value
@@ -10,7 +11,6 @@ from confidential_backend.wrapped_session import get_session_value
 blueprint = Blueprint('fhir', __name__)
 r4prefix = '/v/r4/fhir'
 
-PROXY_HEADERS = ('Authorization', 'Cache-Control', 'Content-Type')
 # including OPTIONS conflicts with flask-cors
 SUPPORTED_METHODS = ('GET', 'POST', 'PUT', 'DELETE')
 

--- a/confidential_backend/auth/views.py
+++ b/confidential_backend/auth/views.py
@@ -1,6 +1,8 @@
 from flask import Blueprint, current_app, redirect, request, url_for, session
+from flask_cors import cross_origin
 import requests
 
+from confidential_backend import PROXY_HEADERS
 from confidential_backend.audit import audit_entry
 from confidential_backend.auth.helpers import extract_payload, format_as_jwt
 from confidential_backend.extensions import oauth
@@ -177,6 +179,7 @@ def authorize():
 
 
 @blueprint.route('/auth-info')
+@cross_origin(allowed_headers=PROXY_HEADERS)
 def auth_info():
     token_response = session['token_response']
     iss = session['iss']


### PR DESCRIPTION
See also PR #7, where this fix was applied but only to the views known at the time to need CORS access from a confidential client front-end.