### PR TITLE
Need to include the `Accept` header in requests proxied to FHIR

### DIFF
--- a/confidential_backend/__init__.py
+++ b/confidential_backend/__init__.py
@@ -1,1 +1,1 @@
-PROXY_HEADERS = ('Authorization', 'Cache-Control', 'Content-Type')
+PROXY_HEADERS = ('Accept', 'Authorization', 'Cache-Control', 'Content-Type')


### PR DESCRIPTION
Noticed when receiving XML from EPIC FHIR endpoints - must include the `Accept` header in order to receive "Application/fhir+json" when desired, for example.