### PR TITLE
Feature/flask cors allow headers

### DIFF
--- a/confidential_backend/api/fhir.py
+++ b/confidential_backend/api/fhir.py
@@ -55,7 +55,7 @@ def patient_by_id(id):
 
 @blueprint.route('/fhir-router/', defaults={'relative_path': '', 'session_id': None}, methods=SUPPORTED_METHODS)
 @blueprint.route('/fhir-router/<string:session_id>/<path:relative_path>', methods=SUPPORTED_METHODS)
-@cross_origin(allowed_headers=PROXY_HEADERS)
+@cross_origin(allow_headers=PROXY_HEADERS)
 def route_fhir(relative_path, session_id):
     g.session_id = session_id
     current_app.logger.debug('received session_id as path parameter: %s', session_id)

--- a/confidential_backend/auth/views.py
+++ b/confidential_backend/auth/views.py
@@ -179,7 +179,7 @@ def authorize():
 
 
 @blueprint.route('/auth-info')
-@cross_origin(allowed_headers=PROXY_HEADERS)
+@cross_origin(allow_headers=PROXY_HEADERS)
 def auth_info():
     token_response = session['token_response']
     iss = session['iss']


### PR DESCRIPTION
noticed logfile complaint:
```
{"asctime": "2023-05-09 21:44:25,369", "name": "flask_cors.core", "levelname": "WARNING", "message": "Unknown option passed to Flask-CORS: allowed_headers"}
```

corrected to conform to the spelling used in [the docs](https://flask-cors.corydolphin.com/en/latest/api.html#extension). 