### PR TITLE
Log payload from token passed to `authorize`

### DIFF
--- a/confidential_backend/auth/views.py
+++ b/confidential_backend/auth/views.py
@@ -28,6 +28,21 @@ LAUNCH_VALUE_TO_CODE = {
 }
 
 
+# A number of undesired attributes from the auth token - removed before logging
+AUTH_TOKEN_LOG_FILTER = (
+    "access_token",
+    "refresh_token",
+    "token_type",
+    "expires_in",
+    "refresh_expires_in",
+    "scope",
+    "id_token",
+    "need_patient_banner",
+    "not-before-policy",
+    "smart_style_url",
+)
+
+
 blueprint = Blueprint('auth', __name__, url_prefix='/auth')
 
 
@@ -60,7 +75,10 @@ def bytes_to_json(byte_string):
     except json.JSONDecodeError:
         return clean
 
-    return json_data
+    # Avoid noise in logs, remove a number of relatively useless attributes
+    filter = current_app.config.get('AUTH_TOKEN_LOG_FILTER') or AUTH_TOKEN_LOG_FILTER
+    keepers = {k:v for k,v in json_data.items() if k not in filter}
+    return keepers
 
 
 def debugging_compliance_fix(session):

--- a/confidential_backend/auth/views.py
+++ b/confidential_backend/auth/views.py
@@ -156,6 +156,9 @@ def authorize():
     # https://github.com/lepture/authlib/blob/master/authlib/oauth2/client.py#L154
     token_response = oauth.sof.authorize_access_token(_format='json')
     extracted_id_token = extract_payload(token_response.get('id_token'))
+    audit_entry(
+        "JWT payload",
+        extra={'tags':['JWT', "authorize"], 'payload': extracted_id_token})
     username = extracted_id_token.get('preferred_username')
 
     # standalone uses profile

--- a/confidential_backend/auth/views.py
+++ b/confidential_backend/auth/views.py
@@ -51,6 +51,9 @@ def debugging_compliance_fix(session):
         current_app.logger.debug('access_token response.status_code: %s', response.status_code)
         current_app.logger.debug('access_token response.content: %s', response.content)
 
+        audit_entry(
+            "access_token content",
+            extra={'tags':['JWT', "authorize", "token"], 'content': response.content})
         response.raise_for_status()
 
         return response
@@ -156,9 +159,6 @@ def authorize():
     # https://github.com/lepture/authlib/blob/master/authlib/oauth2/client.py#L154
     token_response = oauth.sof.authorize_access_token(_format='json')
     extracted_id_token = extract_payload(token_response.get('id_token'))
-    audit_entry(
-        "JWT payload",
-        extra={'tags':['JWT', "authorize"], 'payload': extracted_id_token})
     username = extracted_id_token.get('preferred_username')
 
     # standalone uses profile

--- a/confidential_backend/config.py
+++ b/confidential_backend/config.py
@@ -6,7 +6,6 @@ import os
 import redis
 
 AUTH_TOKEN_LOG_FILTER = os.getenv("AUTH_TOKEN_LOG_FILTER").split(",") if "AUTH_TOKEN_LOG_FILTER" in os.environ else None
-s
 DEBUG_OUTPUT_DIR = os.getenv("DEBUG_OUTPUT_DIR", '/tmp')
 SERVER_NAME = os.getenv("SERVER_NAME")
 SECRET_KEY = os.getenv("SECRET_KEY")

--- a/confidential_backend/config.py
+++ b/confidential_backend/config.py
@@ -5,7 +5,7 @@ Use env var to override
 import os
 import redis
 
-AUTH_TOKEN_LOG_FILTER = os.getenv("AUTH_TOKEN_LOG_FILTER")
+AUTH_TOKEN_LOG_FILTER = os.getenv("AUTH_TOKEN_LOG_FILTER").split(",") if "AUTH_TOKEN_LOG_FILTER" in os.env else None
 DEBUG_OUTPUT_DIR = os.getenv("DEBUG_OUTPUT_DIR", '/tmp')
 SERVER_NAME = os.getenv("SERVER_NAME")
 SECRET_KEY = os.getenv("SECRET_KEY")

--- a/confidential_backend/config.py
+++ b/confidential_backend/config.py
@@ -5,6 +5,7 @@ Use env var to override
 import os
 import redis
 
+AUTH_TOKEN_LOG_FILTER = os.getenv("AUTH_TOKEN_LOG_FILTER")
 DEBUG_OUTPUT_DIR = os.getenv("DEBUG_OUTPUT_DIR", '/tmp')
 SERVER_NAME = os.getenv("SERVER_NAME")
 SECRET_KEY = os.getenv("SECRET_KEY")

--- a/confidential_backend/config.py
+++ b/confidential_backend/config.py
@@ -5,7 +5,8 @@ Use env var to override
 import os
 import redis
 
-AUTH_TOKEN_LOG_FILTER = os.getenv("AUTH_TOKEN_LOG_FILTER").split(",") if "AUTH_TOKEN_LOG_FILTER" in os.env else None
+AUTH_TOKEN_LOG_FILTER = os.getenv("AUTH_TOKEN_LOG_FILTER").split(",") if "AUTH_TOKEN_LOG_FILTER" in os.environ else None
+s
 DEBUG_OUTPUT_DIR = os.getenv("DEBUG_OUTPUT_DIR", '/tmp')
 SERVER_NAME = os.getenv("SERVER_NAME")
 SECRET_KEY = os.getenv("SECRET_KEY")


### PR DESCRIPTION
Fix for issue #11 , logging info in payload of authorize token after launch.

By default, a number of attributes found in the auth token will be stripped out before sending to the log server, to keep it clean.  Set `AUTH_TOKEN_LOG_FILTER` to a reduced set, if desired.