### PR TITLE
thread safe oauth client registration

### DIFF
--- a/confidential_backend/auth/views.py
+++ b/confidential_backend/auth/views.py
@@ -215,8 +215,10 @@ def authorize():
         g.session_id = request.args['session_id']
 
     # if we land in a different thread of execution, need to re-register
+    # NB: peering into oauth's internal `_registry` dict a no-no, but
+    # at time of implementation, no other mechanism was found
     sof_client_params = session['sof_client_params']
-    if sof_client_params['name'] not in oauth:
+    if not oauth._registry.get(sof_client_params['name']):
         oauth.init_app(current_app)
         oauth.register(**sof_client_params)
 


### PR DESCRIPTION
Fix for https://app.shortcut.com/cirg/story/1804

The oauth client registration happens when the `/launch` view is first executed.  If a different worker thread responds to the oauth dance callback (to `/auth/authorize`), the system would error as the `sof` client isn't registered within that memory space.

To mitigate this challenge, include the redis session ID in the oauth callback uri as a query string parameter, so a separate thread can load the same session info.  Within the callback, initialize and register the oauth client if not present in the responding worker thread.

`debugging_compliance_fix` was found to be obsolete and removed in this PR, as the attempt to push the parameters used in oauth client registration would fail, as a function can not be serialized for session storage. 