### PR TITLE
Add Access-Control-Allow-Origin to CORS headers

### DIFF
--- a/confidential_backend/auth/views.py
+++ b/confidential_backend/auth/views.py
@@ -300,5 +300,6 @@ def after_request_func(response):
     # allow requests with cookies to auth-info endpoint
     if request.path == "/auth/auth-info":
         response.headers['Access-Control-Allow-Credentials'] = 'true'
+        response.headers['Access-Control-Allow-Origin'] = '*'
 
     return response


### PR DESCRIPTION
Add Access-Control-Allow-Origin to CORS headers for /auth/auth-info given problems seen in testing.