### PR TITLE
handle null response from fhir server

### DIFF
--- a/confidential_backend/api/fhir.py
+++ b/confidential_backend/api/fhir.py
@@ -1,3 +1,4 @@
+from json.decoder import JSONDecodeError
 import requests
 
 from flask import Blueprint, current_app, g, request
@@ -46,7 +47,12 @@ def empty_response(response):
         # the launch FHIR returns a 410 as it doesn't recognize
         # the next page reference
         return True
-    results = response.json()
+    try:
+        results = response.json()
+    except JSONDecodeError as jde:
+        # rather than catch every form of exception / status code, treat
+        # a lack of valid json response as empty
+        return True
     if results.get('resourceType') == 'Bundle':
         return results.get('total', -1) == 0
     # handle servers that don't set total


### PR DESCRIPTION
rather than capture every unexpected server status, treat non json response (including null) as an empty to allow for other servers a chance to handle the request.

discovered when attempting to PUT a DocumentResource to EPIC*:

```
confidentialbackend-1  |   File "/opt/app/confidential_backend/api/fhir.py", line 49, in empty_response
confidentialbackend-1  |     results = response.json()
confidentialbackend-1  |   File "/usr/local/lib/python3.9/site-packages/requests/models.py", line 910, in json
confidentialbackend-1  |     return complexjson.loads(self.text, **kwargs)
confidentialbackend-1  |   File "/usr/local/lib/python3.9/json/__init__.py", line 346, in loads
confidentialbackend-1  |     return _default_decoder.decode(s)
confidentialbackend-1  |   File "/usr/local/lib/python3.9/json/decoder.py", line 337, in decode
confidentialbackend-1  |     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
confidentialbackend-1  |   File "/usr/local/lib/python3.9/json/decoder.py", line 355, in raw_decode
confidentialbackend-1  |     raise JSONDecodeError("Expecting value", s, err.value) from None
```

*no, we shouldn't be attempting to write to EPIC here, but regardless, the server exception isn't the right response and this fix will help prevent similar misconfiguration of scopes in the future.