### PR TITLE
Fixup 2nd source error handling

### DIFF
--- a/confidential_backend/api/fhir.py
+++ b/confidential_backend/api/fhir.py
@@ -52,6 +52,7 @@ def empty_response(response):
     # handle servers that don't set total
     if results.get('resourceType') == 'Bundle' and not results.get('entry'):
         return True
+    response.raise_for_status()
     return False
 
 
@@ -143,7 +144,6 @@ def route_fhir(relative_path, session_id):
         if secondary_response:
             return secondary_response.json()
 
-    upstream_response.raise_for_status()
     if relative_path.startswith('Patient'):
         # Patient lookup after launch - obtain secondary FHIR server Patient.id
         # for all configured secondary sources

--- a/confidential_backend/api/fhir.py
+++ b/confidential_backend/api/fhir.py
@@ -132,7 +132,6 @@ def route_fhir(relative_path, session_id):
                 headers=upstream_headers,
                 original_request=request
             )
-            secondary_response.raise_for_status()
             fhir_logger.info({
                 "message": "response",
                 "fhir_server": source.name,


### PR DESCRIPTION
Move error handling to `empty_response()`, so exceptions aren't raised for "empty" responses (400, 404, 410)

Found in testing uwcirg/embedhw-environments/pull/24