### PR TITLE
correct PUT/POST requests to secondary fhir endpoints

### DIFF
--- a/confidential_backend/api/fhir.py
+++ b/confidential_backend/api/fhir.py
@@ -33,19 +33,22 @@ def empty_response(response):
     """Check for valid / empty response from FHIR server
 
     :param response: response from FHIR server
-    :returns: True if the response is empty or 404, False otherwise
+    :returns: True if the response is empty or has a staus >= 400, False if
+      a valid response includes at least one entry
     """
-    if response.status_code == 400:
-        # Requests for Questionnaire raises BadRequest.  Swallow
-        # to give secondary FHIR servers a chance to respond
+    if response is None:
         return True
-    if response.status_code == 404:
+
+    if response.status_code >= 400:
+        # A number of scenarios can provoke an invalid response, such
+        # as a request for a Questionnaire the end system doesn't allow,
+        # a page reference from a secondary source, or a disallowed request.
+
+        # treat all such status codes as empty responses, such that secondary
+        # sources can get a chance to respond.  errors will be handled after
+        # secondary sources, if no valid response is found.
         return True
-    if response.status_code == 410:
-        # when paging through the secondary servers response,
-        # the launch FHIR returns a 410 as it doesn't recognize
-        # the next page reference
-        return True
+
     results = response.json()
     if results.get('resourceType') == 'Bundle':
         return results.get('total', -1) == 0
@@ -104,22 +107,28 @@ def route_fhir(relative_path, session_id):
         raise ve
     req_scope = request_scope(
         context="patient", request_path=relative_path, http_method=request.method)
-    allowed_launch_request = request_allowed(req_scope, allowed_scopes)
 
-    if allowed_launch_request:
+    upstream_response = None
+    if request_allowed(req_scope, allowed_scopes):
         upstream_response = requests.request(
             url=upstream_fhir_url,
             method=request.method,
             headers=upstream_headers,
             params=request.args,
-            json=request.json if request.method in ('POST', 'PUT') else None
+            json=request.json if request.method in ('POST', 'PUT', 'PATCH') else None
         )
-    if not allowed_launch_request or empty_response(upstream_response) and secondary_sources:
+
+    if empty_response(upstream_response):
         # If no results found from upstream (aka LAUNCH) FHIR server, try secondary
         secondary_response = None
         for source in secondary_sources:
             # can't continue without a patient_id for this server
             if not source.translated_patient_id():
+                # generate valid 404 response given that lookup failed
+                secondary_response = requests.models.Response()
+                secondary_response._content = b'{"error": "Patient identifier not found"}'
+                secondary_response.headers['Content-Type'] = 'application/json'
+                secondary_response.status_code = 404
                 continue
 
             if not source.allowed_request(req_scope):
@@ -140,9 +149,11 @@ def route_fhir(relative_path, session_id):
                 # only continue on additional sources without results
                 break
 
-        if secondary_response:
+        if secondary_response is not None:
             return secondary_response.json()
 
+    if upstream_response is None:
+        raise ValueError("request not allowed on launch FHIR and nothing found in secondary sources")
     upstream_response.raise_for_status()
     if relative_path.startswith('Patient'):
         # Patient lookup after launch - obtain secondary FHIR server Patient.id

--- a/confidential_backend/api/fhir.py
+++ b/confidential_backend/api/fhir.py
@@ -126,7 +126,7 @@ def route_fhir(relative_path, session_id):
             if not source.translated_patient_id():
                 # generate valid 404 response given that lookup failed
                 secondary_response = requests.models.Response()
-                secondary_response._content = b'{"error": "Patient identifier not found"}'
+                secondary_response._content = b'{"error": "This patient does not yet have data reported from the CNICS PRO system. If the patient has indeed completed a CNICS PRO assessment, please write to cnics-pros@uw.edu for help."}'
                 secondary_response.headers['Content-Type'] = 'application/json'
                 secondary_response.status_code = 404
                 fhir_logger.info({

--- a/confidential_backend/api/fhir.py
+++ b/confidential_backend/api/fhir.py
@@ -126,9 +126,9 @@ def route_fhir(relative_path, session_id):
             if not source.translated_patient_id():
                 # generate valid 404 response given that lookup failed
                 secondary_response = requests.models.Response()
-                secondary_response._content = b'{"error": "This patient does not yet have data reported from the CNICS PRO system. If the patient has indeed completed a CNICS PRO assessment, please write to cnics-pros@uw.edu for help."}'
+                secondary_response._content = b'{"warning": "matching patient identifier not found"}'
                 secondary_response.headers['Content-Type'] = 'application/json'
-                secondary_response.status_code = 404
+                secondary_response.status_code = 200
                 fhir_logger.info({
                     "message": "response",
                     "fhir_server": source.name,

--- a/confidential_backend/api/fhir.py
+++ b/confidential_backend/api/fhir.py
@@ -129,6 +129,11 @@ def route_fhir(relative_path, session_id):
                 secondary_response._content = b'{"error": "Patient identifier not found"}'
                 secondary_response.headers['Content-Type'] = 'application/json'
                 secondary_response.status_code = 404
+                fhir_logger.info({
+                    "message": "response",
+                    "fhir_server": source.name,
+                    "fhir": secondary_response.json(),
+                    "status_code": secondary_response.status_code})
                 continue
 
             if not source.allowed_request(req_scope):

--- a/confidential_backend/api/fhir.py
+++ b/confidential_backend/api/fhir.py
@@ -150,7 +150,7 @@ def route_fhir(relative_path, session_id):
                 break
 
         if secondary_response is not None:
-            return secondary_response.json()
+            return secondary_response.json(), secondary_response.status_code
 
     if upstream_response is None:
         raise ValueError("request not allowed on launch FHIR and nothing found in secondary sources")
@@ -167,4 +167,4 @@ def route_fhir(relative_path, session_id):
         "fhir_server": "LAUNCH FHIR",
         "fhir": upstream_response.json()})
 
-    return upstream_response.json()
+    return upstream_response.json(), upstream_response.status_code

--- a/confidential_backend/app.py
+++ b/confidential_backend/app.py
@@ -83,4 +83,8 @@ def configure_proxy(app):
 
 def configure_secondary_sources(app):
     """Add any configured additional sources, beyond the required launch FHIR server"""
-    secondary_sources.extend(load_strategies(app))
+    strats = load_strategies(app)
+    for strat in strats:
+        # avoid pushing duplicates as factory calls for app and celery stack
+        if not any(s.name == strat.name for s in secondary_sources):
+            secondary_sources.append(strat)

--- a/confidential_backend/source_strategies/secondary_fhir_strategy.py
+++ b/confidential_backend/source_strategies/secondary_fhir_strategy.py
@@ -1,5 +1,8 @@
 """Source Strategy implementation for a FHIR server in a secondary (non launch) role."""
+from copy import deepcopy
+
 from fhir.smart.scopes import scopes
+import json
 import re
 import requests
 from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
@@ -66,6 +69,42 @@ class SecondaryFhirStrategy(SourceStrategy):
             query = query._replace(query=urlencode(updated_query))
 
         return '/'.join((self._server_url, urlunparse(query)))
+
+    def adjust_patient_in_request_json(self, original_request_json, launch_pid):
+        """Correct any patient references in request body (json)
+
+        If the request body, used in PUT/POST, includes references to the launch patient id,
+        correct to this secondary source's respective patient id and return the resulting JSON.
+
+        NB this only looks at the top level of the request json for efficiency and expected use.
+
+        :param request_json: request.json, typically a FHIR Resource that may include references
+          to the launch server's patient id.
+        :param launch_pid: patient id for the patient of interest from launch server's perspective
+
+        Launch server and strategy implementation server often have different patient ids for the
+        same patient (typically linked by a secondary identifier, such as MRN).
+
+        :returns: json for equivalent request against implementation server.
+        """
+        if not original_request_json:
+            return None
+
+        corrected_patient_id = self.translated_patient_id()
+        improved_request_json = deepcopy(original_request_json)
+
+        # replace as values or reference strings, i.e. Patient/<launch_pid>
+        escaped = re.escape(launch_pid)
+        reference_pattern = re.compile(rf'(?<=/){escaped}\b')
+        for key, value in original_request_json.items():
+            if value == launch_pid:
+                improved_request_json[key] = corrected_patient_id
+            value_str = json.dumps(value)
+            if reference_pattern.search(value_str):
+                value_str = reference_pattern.sub(corrected_patient_id, value_str)
+                improved_request_json[key] = json.loads(value_str)
+
+        return improved_request_json
 
     def allowed_request(self, request_scope):
         return request_allowed(request_scope, self._scopes)
@@ -175,11 +214,16 @@ class SecondaryFhirStrategy(SourceStrategy):
         # The original request prior to request_path names unwanted details
         full_path = original_request.url[original_request.url.find(request_path):]
         secondary_fhir_url = self.adjust_patient_query(full_path, launch_patient_id)
+        secondary_request_json = None
+        if original_request.method in ('POST', 'PUT'):
+            secondary_request_json = self.adjust_patient_in_request_json(
+                original_request.json, launch_patient_id)
+
         current_app.logger.debug(f"attempt secondary FHIR request {secondary_fhir_url}")
         secondary_response = requests.request(
             url=secondary_fhir_url,
             method=original_request.method,
             headers=headers,
-            json=original_request.json if original_request.method in ('POST', 'PUT') else None
+            json=secondary_request_json,
         )
         return secondary_response

--- a/confidential_backend/source_strategies/secondary_fhir_strategy.py
+++ b/confidential_backend/source_strategies/secondary_fhir_strategy.py
@@ -215,7 +215,7 @@ class SecondaryFhirStrategy(SourceStrategy):
         full_path = original_request.url[original_request.url.find(request_path):]
         secondary_fhir_url = self.adjust_patient_query(full_path, launch_patient_id)
         secondary_request_json = None
-        if original_request.method in ('POST', 'PUT'):
+        if original_request.method in ('POST', 'PUT', 'PATCH'):
             secondary_request_json = self.adjust_patient_in_request_json(
                 original_request.json, launch_patient_id)
 

--- a/tests/test_multi_fhir.py
+++ b/tests/test_multi_fhir.py
@@ -1,22 +1,36 @@
 """Tests for multiple FHIR endpoints."""
 from copy import deepcopy
 from unittest.mock import patch
+
+import pytest
+
 from confidential_backend.source_strategies.secondary_fhir_strategy import SecondaryFhirStrategy
 
+launch_system = "http://launch/system/mrn"
+app_system = "http://app/system/mrn"
+app_fhir_url = "http://fhir:8080"
+mrn = "be-12-fe"
 
-@patch("confidential_backend.source_strategies.secondary_fhir_strategy.requests.get")
-def test_secondary_patient_lookup(mock_get, app):
-    launch_system = "http://launch/system/mrn"
-    app_system = "http://app/system/mrn"
-    app_fhir_url = "http://fhir:8080"
-    mrn = "be-12-fe"
-    launch_patient = {
+
+@pytest.fixture
+def launch_patient():
+    return {
         "resourceType": "Patient",
         "id": "abc123",
         "identifier": [ {"system": launch_system, "value": mrn} ]
     }
-    app_patient = deepcopy(launch_patient)
-    app_patient["identifier"] = [ {"system": app_system, "value": mrn} ]
+
+@pytest.fixture
+def app_patient():
+    return {
+        "resourceType": "Patient",
+        "id": "different-from-launch-id",
+        "identifier": [{"system": app_system, "value": mrn}]
+    }
+
+
+@patch("confidential_backend.source_strategies.secondary_fhir_strategy.requests.get")
+def test_secondary_patient_lookup(mock_get, app, launch_patient, app_patient):
     search_result = {
         "resourceType": "Bundle",
         "total": 1,
@@ -44,3 +58,28 @@ def test_secondary_patient_lookup(mock_get, app):
     expected_params = {"identifier": f"{app_system}|{mrn}"}
     mock_get.assert_called_once_with(expected_url, params=expected_params)
     assert result == app_patient
+
+
+def test_secondary_patient_put(mocker, launch_patient, app_patient):
+    mocker.patch(
+        "confidential_backend.source_strategies.secondary_fhir_strategy.SecondaryFhirStrategy.translated_patient_id",
+        return_value="different-from-launch-id",
+    )
+
+    secondary_fhir_strategy = SecondaryFhirStrategy(
+        name="TestStrategy",
+        server_url=app_fhir_url,
+        mrn_system=app_system,
+        launch_mrn_systems=f"{launch_system}",
+    )
+    resource = {
+        "resourceType": "DocumentReference",
+        "id": "docref1",
+        "subject": {"reference": f"Patient/{launch_patient['id']}"},
+        "author": [{"reference": f"Patient/{launch_patient['id']}"},]
+    }
+
+    result = secondary_fhir_strategy.adjust_patient_in_request_json(
+        original_request_json=resource, launch_pid=launch_patient['id'])
+    assert result['id'] == resource['id']
+    assert result['subject']['reference'] == f"Patient/{app_patient['id']}"


### PR DESCRIPTION
for secondary FHIR sources, PUT/POST requests may contain FHIR resources referencing the Patient.id as defined by the `launch FHIR server`, but unknown to the secondary source.  Avoid referential integrity errors by replacing the launch patient id with the secondary source's patient id.

this PR includes a number of steps to make handling of empty and invalid responses more robust, including:
- don't halt processing if the LAUNCH FHIR server raises an error (status >= 400), allow secondary to process and if still no valid response, then raise the error
- include the http status code in the response, so upstream clients can react appropriately
- prevent addition of duplicate SECONDARY_SOURCE_STRATEGIES during application initialization
